### PR TITLE
Bugfix: Playground execution fails in presence of Xcode generated files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "swift-playgrounds",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Swift Playgrounds",
 	"description": "Allows opening and running of Swift playground bundles.",
 	"publisher": "pieterjongsma",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"icon": "media/icon.png",
 	"preview": true,
 	"license": "GPL-3.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	vscode.workspace.onDidChangeTextDocument(event => {
-		console.log("Document changed", event);
+		// console.log("Document changed", event);
 		// TODO: Should respond to changes
 	});
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -39,7 +39,7 @@ export default class Playground {
 	}
 
 	public async preparePackage(): Promise<void> {
-		console.log("Preparing at", this._scratchPath);
+		console.log("Preparing Playground at", this._scratchPath);
 
 		// Delete any existing directory (recursively)
 		rimraf.sync(this._scratchPath);
@@ -69,8 +69,6 @@ export default class Playground {
 	}
 
 	public getManifest(stdoutStream?: Writable | undefined, stderrStream?: Writable | undefined): Promise<JSON> {
-		console.info("GET MANIFEST");
-
 		const buffer = new WritableStreamBuffer();
 
 		const cmd = "swiftc";
@@ -99,8 +97,6 @@ export default class Playground {
 	}
 
 	compile(stdoutStream: Writable | undefined, stderrStream: Writable | undefined): Promise<void> {
-		console.info("COMPILE");
-
 		const cmd = "swift";
 		const args = [
 			"build",
@@ -118,8 +114,6 @@ export default class Playground {
 	}
 
 	execute(callbackStream: Writable, stdoutStream: Writable | undefined, stderrStream: Writable | undefined): Promise<void> {
-		console.info("EXECUTE");
-
 		const cmd = "swift";
 		const args = [
 			"run",

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,13 +1,12 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import * as cp from 'child_process';
 import * as ndjson from 'ndjson';
 import { MD5 } from 'crypto-js';
 import * as rimraf from 'rimraf';
 
-import { copyDirectory, copyMissingFiles, copyIfMissing, readdirSyncRecursive, isFile, parentDirMatching } from 'util/file';
-import { run, writableForCallback, promiseSequence } from 'util/child_process';
+import { copyMissingFiles, copyIfMissing, readdirSyncRecursive, isFile, parentDirMatching } from 'util/file';
+import { run, writableForCallback } from 'util/child_process';
 import { Writable } from 'stream';
 import { WritableStreamBuffer } from 'stream-buffers';
 

--- a/src/test/playgrounds/examples/compile_time_error.playground/Contents.swift
+++ b/src/test/playgrounds/examples/compile_time_error.playground/Contents.swift
@@ -1,0 +1,4 @@
+
+print("I like 💩")
+
+sayHello()

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,29 +1,30 @@
 
 import * as os from 'os';
 import * as program from 'commander';
-import { inspect } from 'util';
 
 import Playground from '../playground';
 
 program
-    .version('0.2.0');
-
-program
     .command("run <file>")
     .description("Compiles and runs a Playground")
-    .action(file => {
+    .action(async file => {
         console.log(`Building Playground ${file}`);
         const playground = playgroundForFile(file);
 
-        playground.run(json => {
-            console.log(json);
-        })
-        .then(() => {
+        try {
+            await playground.run(json => {
+                console.log(json);
+            }, (stdout: string) => {
+                console.log(stdout);
+            }, (stderr: string) => {
+                console.error(stderr);
+            });
+
             console.log("Playground executed succesfully");
-        })
-        .catch((err: any) => {
-            console.error("Playground failed to execute", err);
-        });
+        } catch(e) {
+            console.error("Playground failed to execute", e);
+            process.exit(1);
+        }
     });
 
 program

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -57,13 +57,13 @@ export function createDirectoriesForFile(file: string) {
 	}
 }
 
-function readdirSyncRecursive(p: string, a: string[] = []): string[] {
+export function readdirSyncRecursive(p: string, a: string[] = []): string[] {
 	if (fs.statSync(p).isDirectory()) {
 		fs.readdirSync(p).map(f => readdirSyncRecursive(a[a.push(path.join(p, f)) - 1], a));
 	}
 	return a;
 }
 
-function isFile(path: string): boolean {
+export function isFile(path: string): boolean {
 	return !fs.statSync(path).isDirectory();
 }


### PR DESCRIPTION
This PR fixes issues attempting to copy files in `*.xcworkspace` and Swift Package Manager's `.build` directories by not copying them at all. They are not required for execution.